### PR TITLE
Fix ci on Linux and MacOS

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -115,7 +115,7 @@ jobs:
 
     - name: Get some data
       run: |
-        curl -L http://download.ecmwf.int/test-data/magics/2m_temperature.grib -o data.grib
+        curl -L https://get.ecmwf.int/repository/test-data/metview/gallery/2m_temperature.grib -o data.grib
         curl -L https://github.com/ecmwf/climetlab/raw/main/docs/examples/test.grib -o climetlab.grib
         curl -L https://github.com/ecmwf/climetlab/raw/main/docs/examples/test.nc -o climetlab.nc
         ls -l

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -139,6 +139,7 @@ jobs:
 
     - name: Get some data
       run: |
+        curl -L https://get.ecmwf.int/repository/test-data/metview/gallery/2m_temperature.grib  -o data.grib
         curl -L https://github.com/ecmwf/climetlab/raw/main/docs/examples/test.grib -o climetlab.grib
         curl -L https://github.com/ecmwf/climetlab/raw/main/docs/examples/test.nc -o climetlab.nc
         ls -l

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -139,7 +139,6 @@ jobs:
 
     - name: Get some data
       run: |
-        curl -L http://download.ecmwf.int/test-data/magics/2m_temperature.grib -o data.grib
         curl -L https://github.com/ecmwf/climetlab/raw/main/docs/examples/test.grib -o climetlab.grib
         curl -L https://github.com/ecmwf/climetlab/raw/main/docs/examples/test.nc -o climetlab.nc
         ls -l

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -169,7 +169,7 @@ jobs:
 
     - name: Get some data
       run: |
-        curl -L http://download.ecmwf.int/test-data/magics/2m_temperature.grib -o data.grib
+        curl -L https://get.ecmwf.int/repository/test-data/metview/gallery/2m_temperature.grib  -o data.grib
         curl -L https://github.com/ecmwf/climetlab/raw/main/docs/examples/test.grib -o climetlab.grib
         curl -L https://github.com/ecmwf/climetlab/raw/main/docs/examples/test.nc -o climetlab.nc
         ls -l

--- a/scripts/build-linux.sh
+++ b/scripts/build-linux.sh
@@ -111,8 +111,9 @@ ninja -C build-other/pixman install
 # Build cairo
 # -Dqt=disabled
 
-[[ -d src/cairo ]] || git clone --depth 1 $GIT_CAIRO src/cairo
+[[ -d src/cairo ]] || git clone $GIT_CAIRO src/cairo
 cd src/cairo
+git checkout $CAIRO_VERSION
 meson setup --prefix=$TOPDIR/install \
     -Dwrap_mode=nofallback \
     -Dxlib=disabled \

--- a/scripts/build-linux.sh
+++ b/scripts/build-linux.sh
@@ -117,7 +117,6 @@ meson setup --prefix=$TOPDIR/install \
     -Dwrap_mode=nofallback \
     -Dxlib=disabled \
     -Dxcb=disabled \
-    -Dgl-backend=disabled \
     $TOPDIR/build-other/cairo
 
 cd $TOPDIR

--- a/scripts/build-windows.sh
+++ b/scripts/build-windows.sh
@@ -21,9 +21,9 @@ cd $here
 echo git $url $sha1 > versions
 
 if [[ $WINARCH == "x64" ]]; then
-    PKG_CONFIG_EXECUTABLE=/c/rtools40/mingw64/bin/pkg-config.exe
+    PKG_CONFIG_EXECUTABLE=/c/rtools43/mingw64/bin/pkg-config.exe
 else
-    PKG_CONFIG_EXECUTABLE=/c/rtools40/mingw32/bin/pkg-config.exe
+    PKG_CONFIG_EXECUTABLE=/c/rtools43/mingw32/bin/pkg-config.exe
 fi
 
 for p in expat netcdf-c[core,netcdf-4,hdf5] pango sqlite3[core,tool] libpng

--- a/scripts/build-windows.sh
+++ b/scripts/build-windows.sh
@@ -20,7 +20,7 @@ cd $here
 
 echo git $url $sha1 > versions
 
-find / -name pkg-config.exe
+find /c/ -name pkg-config.exe
 exit 1
 
 if [[ $WINARCH == "x64" ]]; then

--- a/scripts/build-windows.sh
+++ b/scripts/build-windows.sh
@@ -20,8 +20,10 @@ cd $here
 
 echo git $url $sha1 > versions
 
-find /c/ -name pkg-config.exe
-exit 1
+# the results of the following suggested that pkg-config.exe is not installed on the latest
+# Windows runner
+#find /c/ -name pkg-config.exe
+#exit 1
 
 if [[ $WINARCH == "x64" ]]; then
     PKG_CONFIG_EXECUTABLE=/c/rtools43/mingw64/bin/pkg-config.exe

--- a/scripts/build-windows.sh
+++ b/scripts/build-windows.sh
@@ -20,6 +20,9 @@ cd $here
 
 echo git $url $sha1 > versions
 
+find / -name pkg-config.exe
+exit 1
+
 if [[ $WINARCH == "x64" ]]; then
     PKG_CONFIG_EXECUTABLE=/c/rtools43/mingw64/bin/pkg-config.exe
 else

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -29,7 +29,7 @@ PROJ_VERSION=master
 GIT_AEC=https://github.com/MathisRosenhauer/libaec.git
 AEC_VERSION=master
 
-GIT_PIXMAN=https://github.com/freedesktop/pixman.git
+GIT_PIXMAN=https://gitlab.freedesktop.org/pixman/pixman
 PIXMAN_VERSION=master
 
 GIT_CAIRO=https://github.com/freedesktop/cairo.git

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -33,7 +33,7 @@ GIT_PIXMAN=https://gitlab.freedesktop.org/pixman/pixman
 PIXMAN_VERSION=master
 
 GIT_CAIRO=https://gitlab.freedesktop.org/cairo/cairo
-CAIRO_VERSION=1.16
+CAIRO_VERSION=1.17.6
 
 GIT_HARFBUZZ=https://github.com/harfbuzz/harfbuzz.git
 HARFBUZZ_VERSION=master

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -33,7 +33,7 @@ GIT_PIXMAN=https://gitlab.freedesktop.org/pixman/pixman
 PIXMAN_VERSION=master
 
 GIT_CAIRO=https://gitlab.freedesktop.org/cairo/cairo
-CAIRO_VERSION=master
+CAIRO_VERSION=1.16
 
 GIT_HARFBUZZ=https://github.com/harfbuzz/harfbuzz.git
 HARFBUZZ_VERSION=master

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -32,7 +32,7 @@ AEC_VERSION=master
 GIT_PIXMAN=https://gitlab.freedesktop.org/pixman/pixman
 PIXMAN_VERSION=master
 
-GIT_CAIRO=https://github.com/freedesktop/cairo.git
+GIT_CAIRO=https://gitlab.freedesktop.org/cairo/cairo
 CAIRO_VERSION=master
 
 GIT_HARFBUZZ=https://github.com/harfbuzz/harfbuzz.git

--- a/tools/copy-licences.py
+++ b/tools/copy-licences.py
@@ -152,7 +152,12 @@ ENTRIES = {
     "libzstd": {
         "home": "https://github.com/facebook/zstd",
         "copying": "https://raw.githubusercontent.com/facebook/zstd/master/LICENSE",
-    }
+    },
+    # not completely clear what the definitive source for this library is
+    "liblzma": {
+        "home": "https://github.com/ShiftMediaProject/liblzma",
+        "copying": "https://raw.githubusercontent.com/ShiftMediaProject/liblzma/master/COPYING",
+    },
     # "libcurl": {
     #     "home": "https://github.com/curl/curl",
     #     "copying": "https://raw.githubusercontent.com/curl/curl/master/COPYING",


### PR DESCRIPTION
This PR fixes the ci for Linux and MacOS, but not for Windows. The latest Windows runner image does not seem to have pkg-config installed (confirmed with a 'find' command, and suggested here: https://github.com/actions/runner-images/releases/tag/win22%2F20231002.1).

Someone will need to decide whether to continue to support Windows (and if so, how to fix this issue).