### PR TITLE
Update artifact actions to v4

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -9,7 +9,6 @@
 name: Build Linux
 
 on:
-
   workflow_dispatch: {}
 
   release:
@@ -20,98 +19,93 @@ on:
 
   push:
     branches:
-    - master
+      - master
     paths:
-    - 'scripts/common.sh'
-    - 'scripts/build-linux.sh'
-    - 'scripts/wheel-linux.sh'
-    - 'tools/copy-licences.py'
+      - "scripts/common.sh"
+      - "scripts/build-linux.sh"
+      - "scripts/wheel-linux.sh"
+      - "tools/copy-licences.py"
   pull_request:
     branches:
-    - master
+      - master
     paths:
-    - 'scripts/common.sh'
-    - 'scripts/build-linux.sh'
-    - 'scripts/wheel-linux.sh'
-    - 'tools/copy-licences.py'
-
+      - "scripts/common.sh"
+      - "scripts/build-linux.sh"
+      - "scripts/wheel-linux.sh"
+      - "tools/copy-licences.py"
 
 jobs:
   build_legacy:
-
     runs-on: ubuntu-latest
     container: dockcross/manylinux2014-x64:20211222-f096312
 
     name: Legacy build manylinux2014
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - run: ./scripts/build-linux.sh
+      - run: ./scripts/build-linux.sh
 
-
-    ################################################################
-    - run: ./scripts/wheel-linux.sh 3.6
-    - uses: actions/upload-artifact@v2
-      name: Upload wheel 3.6
-      with:
-        name: wheel-manylinux2014-3.6
-        path: wheelhouse/*.whl
+      ################################################################
+      - run: ./scripts/wheel-linux.sh 3.6
+      - uses: actions/upload-artifact@v4
+        name: Upload wheel 3.6
+        with:
+          name: wheel-manylinux2014-3.6
+          path: wheelhouse/*.whl
 
   build:
-
     runs-on: ubuntu-latest
     container: dockcross/manylinux2014-x64:latest
 
     name: Build manylinux2014
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - run: ./scripts/build-linux.sh
+      - run: ./scripts/build-linux.sh
 
-    ################################################################
-    - run: ./scripts/wheel-linux.sh 3.7
-    - uses: actions/upload-artifact@v2
-      name: Upload wheel 3.7
-      with:
-        name: wheel-manylinux2014-3.7
-        path: wheelhouse/*.whl
+      ################################################################
+      - run: ./scripts/wheel-linux.sh 3.7
+      - uses: actions/upload-artifact@v4
+        name: Upload wheel 3.7
+        with:
+          name: wheel-manylinux2014-3.7
+          path: wheelhouse/*.whl
 
-    ################################################################
-    - run: ./scripts/wheel-linux.sh 3.8
-    - uses: actions/upload-artifact@v2
-      name: Upload wheel 3.8
-      with:
-        name: wheel-manylinux2014-3.8
-        path: wheelhouse/*.whl
+      ################################################################
+      - run: ./scripts/wheel-linux.sh 3.8
+      - uses: actions/upload-artifact@v4
+        name: Upload wheel 3.8
+        with:
+          name: wheel-manylinux2014-3.8
+          path: wheelhouse/*.whl
 
-    ################################################################
-    - run: ./scripts/wheel-linux.sh 3.9
-    - uses: actions/upload-artifact@v2
-      name: Upload wheel 3.9
-      with:
-        name: wheel-manylinux2014-3.9
-        path: wheelhouse/*.whl
+      ################################################################
+      - run: ./scripts/wheel-linux.sh 3.9
+      - uses: actions/upload-artifact@v4
+        name: Upload wheel 3.9
+        with:
+          name: wheel-manylinux2014-3.9
+          path: wheelhouse/*.whl
 
-    ################################################################
-    - run: ./scripts/wheel-linux.sh 3.10
-    - uses: actions/upload-artifact@v2
-      name: Upload wheel 3.10
-      with:
-        name: wheel-manylinux2014-3.10
+      ################################################################
+      - run: ./scripts/wheel-linux.sh 3.10
+      - uses: actions/upload-artifact@v4
+        name: Upload wheel 3.10
+        with:
+          name: wheel-manylinux2014-3.10
 
-        path: wheelhouse/*.whl
-    ################################################################
-    - run: ./scripts/wheel-linux.sh 3.11
-    - uses: actions/upload-artifact@v2
-      name: Upload wheel 3.11
-      with:
-        name: wheel-manylinux2014-3.11
-        path: wheelhouse/*.whl
+          path: wheelhouse/*.whl
+      ################################################################
+      - run: ./scripts/wheel-linux.sh 3.11
+      - uses: actions/upload-artifact@v4
+        name: Upload wheel 3.11
+        with:
+          name: wheel-manylinux2014-3.11
+          path: wheelhouse/*.whl
 
   test:
-
     needs: build
 
     strategy:
@@ -124,44 +118,42 @@ jobs:
     name: Test with ${{ matrix.python-version }}
 
     steps:
+      - uses: actions/checkout@v2
 
-    - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
 
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
+      - uses: actions/download-artifact@v4
+        with:
+          name: wheel-manylinux2014-${{ matrix.python-version }}
 
-    - uses: actions/download-artifact@v2
-      with:
-        name: wheel-manylinux2014-${{ matrix.python-version }}
+      - run: pip install *.whl
 
-    - run: pip install *.whl
+      - run: pip install -r tests/requirements.txt
 
-    - run: pip install -r tests/requirements.txt
+      - run: pip freeze
 
-    - run: pip freeze
+      - run: env | sort
 
-    - run: env | sort
+      - name: Get some data
+        run: |
+          curl -L https://get.ecmwf.int/repository/test-data/metview/gallery/2m_temperature.grib -o data.grib
+          curl -L https://github.com/ecmwf/climetlab/raw/main/docs/examples/test.grib -o climetlab.grib
+          curl -L https://github.com/ecmwf/climetlab/raw/main/docs/examples/test.nc -o climetlab.nc
+          ls -l
+        working-directory: tests
 
-    - name: Get some data
-      run: |
-        curl -L https://get.ecmwf.int/repository/test-data/metview/gallery/2m_temperature.grib -o data.grib
-        curl -L https://github.com/ecmwf/climetlab/raw/main/docs/examples/test.grib -o climetlab.grib
-        curl -L https://github.com/ecmwf/climetlab/raw/main/docs/examples/test.nc -o climetlab.nc
-        ls -l
-      working-directory: tests
+      - run: pytest -v -s
+        working-directory: tests
 
-    - run: pytest -v -s
-      working-directory: tests
-
-    - uses: actions/upload-artifact@v2
-      with:
-        name: tests-manylinux2014-${{ matrix.python-version }}
-        path: tests/*.png
+      - uses: actions/upload-artifact@v4
+        with:
+          name: tests-manylinux2014-${{ matrix.python-version }}
+          path: tests/*.png
 
   deploy:
-
     if: ${{ github.event_name == 'release' }}
 
     strategy:
@@ -175,23 +167,21 @@ jobs:
 
     runs-on: ubuntu-latest
 
-
     steps:
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          # We cannot use 3.6 as it is not supported anymore by github actions
+          # but we still want to deploy the wheels we built for it
+          python-version: "3.10"
 
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        # We cannot use 3.6 as it is not supported anymore by github actions
-        # but we still want to deploy the wheels we built for it
-        python-version: "3.10"
+      - run: pip install twine
 
-    - run: pip install twine
+      - uses: actions/download-artifact@v4
+        with:
+          name: wheel-manylinux2014-${{ matrix.python-version }}
 
-    - uses: actions/download-artifact@v2
-      with:
-        name: wheel-manylinux2014-${{ matrix.python-version }}
-
-    - run: twine upload *.whl
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+      - run: twine upload *.whl
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/build-macos-arm.yml
+++ b/.github/workflows/build-macos-arm.yml
@@ -19,19 +19,17 @@ on:
 
   push:
     paths:
-    - 'scripts/common.sh'
-    - 'scripts/build-macos.sh'
-    - 'scripts/wheel-macos.sh'
-    - 'tools/copy-licences.py'
+      - "scripts/common.sh"
+      - "scripts/build-macos.sh"
+      - "scripts/wheel-macos.sh"
+      - "tools/copy-licences.py"
 
 # We don't use "actions/setup-python@v4" as it installs a universal python
 # which creates universal wheels. We want to create wheels for the specific
 # architecture we are running on.
 
 jobs:
-
   build:
-
     # if: false
 
     runs-on: [self-hosted, macOS, ARM64]
@@ -40,47 +38,46 @@ jobs:
     name: Build
 
     steps:
+      - run: sudo mkdir -p /Users/runner
+      - run: sudo chown administrator:staff /Users/runner
 
-    - run: sudo mkdir -p /Users/runner
-    - run: sudo chown administrator:staff /Users/runner
+      - uses: actions/checkout@v2
 
-    - uses: actions/checkout@v2
+      - run: ./scripts/select-python.sh "3.10"
+      - run: ./scripts/build-macos.sh
 
-    - run: ./scripts/select-python.sh "3.10"
-    - run: ./scripts/build-macos.sh
+      ################################################################
+      - run: ./scripts/select-python.sh "3.9"
+      - run: ./scripts/wheel-macos.sh "3.9"
+      - run: ls -l wheelhouse
+      - uses: actions/upload-artifact@v4
+        name: Upload wheel 3.9
+        with:
+          name: wheel-macos-3.9
+          path: wheelhouse/*.whl
+      - run: rm -fr wheelhouse
 
-    ################################################################
-    - run: ./scripts/select-python.sh "3.9"
-    - run: ./scripts/wheel-macos.sh "3.9"
-    - run: ls -l wheelhouse
-    - uses: actions/upload-artifact@v2
-      name: Upload wheel 3.9
-      with:
-        name: wheel-macos-3.9
-        path: wheelhouse/*.whl
-    - run: rm -fr wheelhouse
+      ################################################################
+      - run: ./scripts/select-python.sh "3.10"
+      - run: ./scripts/wheel-macos.sh "3.10"
+      - run: ls -l wheelhouse
+      - uses: actions/upload-artifact@v4
+        name: Upload wheel 3.10
+        with:
+          name: wheel-macos-3.10
+          path: wheelhouse/*.whl
+      - run: rm -fr wheelhouse
 
-    ################################################################
-    - run: ./scripts/select-python.sh "3.10"
-    - run: ./scripts/wheel-macos.sh "3.10"
-    - run: ls -l wheelhouse
-    - uses: actions/upload-artifact@v2
-      name: Upload wheel 3.10
-      with:
-        name: wheel-macos-3.10
-        path: wheelhouse/*.whl
-    - run: rm -fr wheelhouse
-
-    ################################################################
-    - run: ./scripts/select-python.sh "3.11"
-    - run: ./scripts/wheel-macos.sh "3.11"
-    - run: ls -l wheelhouse
-    - uses: actions/upload-artifact@v2
-      name: Upload wheel 3.11
-      with:
-        name: wheel-macos-3.11
-        path: wheelhouse/*.whl
-    - run: rm -fr wheelhouse
+      ################################################################
+      - run: ./scripts/select-python.sh "3.11"
+      - run: ./scripts/wheel-macos.sh "3.11"
+      - run: ls -l wheelhouse
+      - uses: actions/upload-artifact@v4
+        name: Upload wheel 3.11
+        with:
+          name: wheel-macos-3.11
+          path: wheelhouse/*.whl
+      - run: rm -fr wheelhouse
 
   test:
     needs: build
@@ -97,46 +94,44 @@ jobs:
     name: Test with Python ${{ matrix.python-version }}
 
     steps:
+      - uses: actions/checkout@v2
 
-    - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v4
+        with:
+          name: wheel-macos-${{ matrix.python-version }}
 
-    - uses: actions/download-artifact@v2
-      with:
-        name: wheel-macos-${{ matrix.python-version }}
+      - run: ls -l
+      - run: ./scripts/select-python.sh  ${{ matrix.python-version }}
+      - run: echo $PATH
+      - run: pip3 install --upgrade pip
+      - run: ls -l /opt/homebrew/opt/python@${{ matrix.python-version }}/libexec/bin
+      - run: which python3
+      - run: python3 --version
+      - run: pwd
+      - run: ls -l
+      - run: pip3 install *.whl
+      - run: pip3 install -r tests/requirements.txt
+      - run: pip3 freeze
 
-    - run: ls -l
-    - run: ./scripts/select-python.sh  ${{ matrix.python-version }}
-    - run: echo $PATH
-    - run: pip3 install --upgrade pip
-    - run: ls -l /opt/homebrew/opt/python@${{ matrix.python-version }}/libexec/bin
-    - run: which python3
-    - run: python3 --version
-    - run: pwd
-    - run: ls -l
-    - run: pip3 install *.whl
-    - run: pip3 install -r tests/requirements.txt
-    - run: pip3 freeze
+      - name: Get some data
+        run: |
+          curl -L https://get.ecmwf.int/repository/test-data/metview/gallery/2m_temperature.grib  -o data.grib
+          curl -L https://github.com/ecmwf/climetlab/raw/main/docs/examples/test.grib -o climetlab.grib
+          curl -L https://github.com/ecmwf/climetlab/raw/main/docs/examples/test.nc -o climetlab.nc
+          ls -l
+        working-directory: tests
 
-    - name: Get some data
-      run: |
-        curl -L https://get.ecmwf.int/repository/test-data/metview/gallery/2m_temperature.grib  -o data.grib
-        curl -L https://github.com/ecmwf/climetlab/raw/main/docs/examples/test.grib -o climetlab.grib
-        curl -L https://github.com/ecmwf/climetlab/raw/main/docs/examples/test.nc -o climetlab.nc
-        ls -l
-      working-directory: tests
+      - run: pytest -v -s
+        working-directory: tests
 
-    - run: pytest -v -s
-      working-directory: tests
+      - uses: actions/upload-artifact@v4
+        with:
+          name: tests-macos-${{ matrix.python-version }}
+          path: tests/*.png
 
-    - uses: actions/upload-artifact@v2
-      with:
-        name: tests-macos-${{ matrix.python-version }}
-        path: tests/*.png
-
-    - run: rm -fr *.whl tests
+      - run: rm -fr *.whl tests
 
   deploy:
-
     if: ${{ github.event_name == 'release' }}
 
     needs: [test, build]
@@ -152,15 +147,14 @@ jobs:
         python-version: ["3.9", "3.10", "3.11"]
 
     steps:
+      - run: ./scripts/select-python.sh ${{ matrix.python-version }}
+      - run: pip3 install twine
 
-    - run: ./scripts/select-python.sh ${{ matrix.python-version }}
-    - run: pip3 install twine
+      - uses: actions/download-artifact@v4
+        with:
+          name: wheel-macos-${{ matrix.python-version }}
 
-    - uses: actions/download-artifact@v2
-      with:
-        name: wheel-macos-${{ matrix.python-version }}
-
-    - run: twine upload *.whl
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+      - run: twine upload *.whl
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/build-macos-intel.yml
+++ b/.github/workflows/build-macos-intel.yml
@@ -19,15 +19,13 @@ on:
 
   push:
     paths:
-    - 'scripts/common.sh'
-    - 'scripts/build-macos.sh'
-    - 'scripts/wheel-macos.sh'
-    - 'tools/copy-licences.py'
+      - "scripts/common.sh"
+      - "scripts/build-macos.sh"
+      - "scripts/wheel-macos.sh"
+      - "tools/copy-licences.py"
 
 jobs:
-
   build:
-
     # if: false
 
     runs-on: macos-latest
@@ -35,75 +33,74 @@ jobs:
     name: Build
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v4
-      with:
-        python-version: 3.7
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.7
 
-    - run: ./scripts/build-macos.sh
+      - run: ./scripts/build-macos.sh
 
+      ################################################################
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.7
+      - run: ./scripts/wheel-macos.sh 3.7
+      - uses: actions/upload-artifact@v4
+        name: Upload wheel 3.7
+        with:
+          name: wheel-macos-3.7
+          path: wheelhouse/*.whl
 
-    ################################################################
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v4
-      with:
-        python-version: 3.7
-    - run: ./scripts/wheel-macos.sh 3.7
-    - uses: actions/upload-artifact@v2
-      name: Upload wheel 3.7
-      with:
-        name: wheel-macos-3.7
-        path: wheelhouse/*.whl
+      ################################################################
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
+      - run: ./scripts/wheel-macos.sh 3.8
+      - uses: actions/upload-artifact@v4
+        name: Upload wheel 3.8
+        with:
+          name: wheel-macos-3.8
+          path: wheelhouse/*.whl
 
-    ################################################################
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v4
-      with:
-        python-version: 3.8
-    - run: ./scripts/wheel-macos.sh 3.8
-    - uses: actions/upload-artifact@v2
-      name: Upload wheel 3.8
-      with:
-        name: wheel-macos-3.8
-        path: wheelhouse/*.whl
+      ################################################################
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+      - run: ./scripts/wheel-macos.sh 3.9
+      - uses: actions/upload-artifact@v4
+        name: Upload wheel 3.9
+        with:
+          name: wheel-macos-3.9
+          path: wheelhouse/*.whl
 
-    ################################################################
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v4
-      with:
-        python-version: 3.9
-    - run: ./scripts/wheel-macos.sh 3.9
-    - uses: actions/upload-artifact@v2
-      name: Upload wheel 3.9
-      with:
-        name: wheel-macos-3.9
-        path: wheelhouse/*.whl
+      ################################################################
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - run: ./scripts/wheel-macos.sh "3.10"
+      - uses: actions/upload-artifact@v4
+        name: Upload wheel 3.10
+        with:
+          name: wheel-macos-3.10
+          path: wheelhouse/*.whl
 
-    ################################################################
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v4
-      with:
-        python-version: "3.10"
-    - run: ./scripts/wheel-macos.sh "3.10"
-    - uses: actions/upload-artifact@v2
-      name: Upload wheel 3.10
-      with:
-        name: wheel-macos-3.10
-        path: wheelhouse/*.whl
-
-    ################################################################
-    - name: Set up Python 3.11
-      uses: actions/setup-python@v4
-      with:
-        python-version: "3.11"
-    - run: ./scripts/wheel-macos.sh "3.11"
-    - uses: actions/upload-artifact@v2
-      name: Upload wheel 3.11
-      with:
-        name: wheel-macos-3.11
-        path: wheelhouse/*.whl
+      ################################################################
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - run: ./scripts/wheel-macos.sh "3.11"
+      - uses: actions/upload-artifact@v4
+        name: Upload wheel 3.11
+        with:
+          name: wheel-macos-3.11
+          path: wheelhouse/*.whl
 
   test:
     needs: build
@@ -116,44 +113,42 @@ jobs:
     name: Test with Python ${{ matrix.python-version }}
 
     steps:
+      - uses: actions/checkout@v2
 
-    - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
 
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
+      - uses: actions/download-artifact@v4
+        with:
+          name: wheel-macos-${{ matrix.python-version }}
 
-    - uses: actions/download-artifact@v2
-      with:
-        name: wheel-macos-${{ matrix.python-version }}
+      - run: python -m pip install --upgrade pip
 
-    - run: python -m pip install --upgrade pip
+      - run: pip install *.whl
 
-    - run: pip install *.whl
+      - run: pip install -r tests/requirements.txt
 
-    - run: pip install -r tests/requirements.txt
+      - run: pip freeze
 
-    - run: pip freeze
+      - name: Get some data
+        run: |
+          curl -L https://get.ecmwf.int/repository/test-data/metview/gallery/2m_temperature.grib  -o data.grib
+          curl -L https://github.com/ecmwf/climetlab/raw/main/docs/examples/test.grib -o climetlab.grib
+          curl -L https://github.com/ecmwf/climetlab/raw/main/docs/examples/test.nc -o climetlab.nc
+          ls -l
+        working-directory: tests
 
-    - name: Get some data
-      run: |
-        curl -L https://get.ecmwf.int/repository/test-data/metview/gallery/2m_temperature.grib  -o data.grib
-        curl -L https://github.com/ecmwf/climetlab/raw/main/docs/examples/test.grib -o climetlab.grib
-        curl -L https://github.com/ecmwf/climetlab/raw/main/docs/examples/test.nc -o climetlab.nc
-        ls -l
-      working-directory: tests
+      - run: pytest -v -s
+        working-directory: tests
 
-    - run: pytest -v -s
-      working-directory: tests
-
-    - uses: actions/upload-artifact@v2
-      with:
-        name: tests-macos-${{ matrix.python-version }}
-        path: tests/*.png
+      - uses: actions/upload-artifact@v4
+        with:
+          name: tests-macos-${{ matrix.python-version }}
+          path: tests/*.png
 
   deploy:
-
     if: ${{ github.event_name == 'release' }}
 
     needs: [test, build]
@@ -167,19 +162,18 @@ jobs:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
 
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
+      - run: pip install twine
 
-    - run: pip install twine
+      - uses: actions/download-artifact@v4
+        with:
+          name: wheel-macos-${{ matrix.python-version }}
 
-    - uses: actions/download-artifact@v2
-      with:
-        name: wheel-macos-${{ matrix.python-version }}
-
-    - run: twine upload *.whl
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+      - run: twine upload *.whl
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -19,11 +19,11 @@ on:
 
   push:
     paths:
-    - 'scripts/common.sh'
-    - 'scripts/build-windows.sh'
-    - 'scripts/wheel-windows.sh'
-    - 'tools/copy-licences.py'
-    - 'tools/copy-dlls.py'
+      - "scripts/common.sh"
+      - "scripts/build-windows.sh"
+      - "scripts/wheel-windows.sh"
+      - "tools/copy-licences.py"
+      - "tools/copy-dlls.py"
 jobs:
   build:
     runs-on: windows-latest
@@ -41,111 +41,110 @@ jobs:
       WINARCH: ${{ matrix.architecture }}
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - uses: seanmiddleditch/gha-setup-vsdevenv@master
-      with:
-        arch: ${{ matrix.architecture }}
+      - uses: seanmiddleditch/gha-setup-vsdevenv@master
+        with:
+          arch: ${{ matrix.architecture }}
 
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: 3.7
-        architecture: ${{ matrix.architecture }}
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.7
+          architecture: ${{ matrix.architecture }}
 
-    - name: Apply mirror
-      if: false
-      run: |
-        import os
-        a = "repo.msys2.org"
-        b = "mirror.yandex.ru/mirrors/msys2"
-        for root, _, files in os.walk("c:/vcpkg"):
-            for f in files:
-              if f.endswith(".cmake"):
-                path = os.path.join(root, f)
-                with open(path) as f:
-                  text = f.read()
-                  changed = text.replace(a, b)
-                if text != changed:
-                  print("CHANGED", path)
-                  with open(path, "w") as f:
-                    f.write(changed)
-      shell: python
+      - name: Apply mirror
+        if: false
+        run: |
+          import os
+          a = "repo.msys2.org"
+          b = "mirror.yandex.ru/mirrors/msys2"
+          for root, _, files in os.walk("c:/vcpkg"):
+              for f in files:
+                if f.endswith(".cmake"):
+                  path = os.path.join(root, f)
+                  with open(path) as f:
+                    text = f.read()
+                    changed = text.replace(a, b)
+                  if text != changed:
+                    print("CHANGED", path)
+                    with open(path, "w") as f:
+                      f.write(changed)
+        shell: python
 
-    - run: ./scripts/build-windows.sh
-      env:
-        WINARCH: ${{ matrix.architecture }}
+      - run: ./scripts/build-windows.sh
+        env:
+          WINARCH: ${{ matrix.architecture }}
 
-    ################################################################
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v4
-      with:
-        python-version: 3.7
-        architecture: ${{ matrix.architecture }}
+      ################################################################
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.7
+          architecture: ${{ matrix.architecture }}
 
-    - run: ./scripts/wheel-windows.sh 3.7
-    - uses: actions/upload-artifact@v2
-      name: Upload wheel 3.7
-      with:
-        name: wheel-windows-3.7-${{ matrix.architecture }}
-        path: wheelhouse/*.whl
+      - run: ./scripts/wheel-windows.sh 3.7
+      - uses: actions/upload-artifact@v4
+        name: Upload wheel 3.7
+        with:
+          name: wheel-windows-3.7-${{ matrix.architecture }}
+          path: wheelhouse/*.whl
 
-    ################################################################
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v4
-      with:
-        python-version: 3.8
-        architecture: ${{ matrix.architecture }}
+      ################################################################
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
+          architecture: ${{ matrix.architecture }}
 
-    - run: ./scripts/wheel-windows.sh 3.8
-    - uses: actions/upload-artifact@v2
-      name: Upload wheel 3.8
-      with:
-        name: wheel-windows-3.8-${{ matrix.architecture }}
-        path: wheelhouse/*.whl
+      - run: ./scripts/wheel-windows.sh 3.8
+      - uses: actions/upload-artifact@v4
+        name: Upload wheel 3.8
+        with:
+          name: wheel-windows-3.8-${{ matrix.architecture }}
+          path: wheelhouse/*.whl
 
-    ################################################################
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v4
-      with:
-        python-version: 3.9
-        architecture: ${{ matrix.architecture }}
+      ################################################################
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+          architecture: ${{ matrix.architecture }}
 
-    - run: ./scripts/wheel-windows.sh 3.9
-    - uses: actions/upload-artifact@v2
-      name: Upload wheel 3.9
-      with:
-        name: wheel-windows-3.9-${{ matrix.architecture }}
-        path: wheelhouse/*.whl
+      - run: ./scripts/wheel-windows.sh 3.9
+      - uses: actions/upload-artifact@v4
+        name: Upload wheel 3.9
+        with:
+          name: wheel-windows-3.9-${{ matrix.architecture }}
+          path: wheelhouse/*.whl
 
-    ################################################################
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v4
-      with:
-        python-version: "3.10"
-        architecture: ${{ matrix.architecture }}
+      ################################################################
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+          architecture: ${{ matrix.architecture }}
 
-    - run: ./scripts/wheel-windows.sh "3.10"
-    - uses: actions/upload-artifact@v2
-      name: Upload wheel 3.10
-      with:
-        name: wheel-windows-3.10-${{ matrix.architecture }}
-        path: wheelhouse/*.whl
+      - run: ./scripts/wheel-windows.sh "3.10"
+      - uses: actions/upload-artifact@v4
+        name: Upload wheel 3.10
+        with:
+          name: wheel-windows-3.10-${{ matrix.architecture }}
+          path: wheelhouse/*.whl
 
-    ################################################################
-    - name: Set up Python 3.11
-      uses: actions/setup-python@v4
-      with:
-        python-version: "3.11"
-        architecture: ${{ matrix.architecture }}
+      ################################################################
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+          architecture: ${{ matrix.architecture }}
 
-    - run: ./scripts/wheel-windows.sh "3.11"
-    - uses: actions/upload-artifact@v2
-      name: Upload wheel 3.11
-      with:
-        name: wheel-windows-3.11-${{ matrix.architecture }}
-        path: wheelhouse/*.whl
-
+      - run: ./scripts/wheel-windows.sh "3.11"
+      - uses: actions/upload-artifact@v4
+        name: Upload wheel 3.11
+        with:
+          name: wheel-windows-3.11-${{ matrix.architecture }}
+          path: wheelhouse/*.whl
 
   test:
     needs: build
@@ -163,40 +162,40 @@ jobs:
     name: Test with Python ${{ matrix.python-version }} ${{ matrix.architecture }}
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
-        architecture: ${{ matrix.architecture }}
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: ${{ matrix.architecture }}
 
-    - uses: actions/download-artifact@v2
-      with:
-        name: wheel-windows-${{ matrix.python-version }}-${{ matrix.architecture }}
+      - uses: actions/download-artifact@v4
+        with:
+          name: wheel-windows-${{ matrix.python-version }}-${{ matrix.architecture }}
 
-    - run: pip install *.whl
+      - run: pip install *.whl
 
-    - run: pip install -r tests/requirements.txt
+      - run: pip install -r tests/requirements.txt
 
-    - run: pip freeze
+      - run: pip freeze
 
-    - name: Get some data
-      run: |
-        curl -L https://get.ecmwf.int/repository/test-data/metview/gallery/2m_temperature.grib  -o data.grib
-        curl -L https://github.com/ecmwf/climetlab/raw/main/docs/examples/test.grib -o climetlab.grib
-        curl -L https://github.com/ecmwf/climetlab/raw/main/docs/examples/test.nc -o climetlab.nc
-        ls -l
-      working-directory: tests
+      - name: Get some data
+        run: |
+          curl -L https://get.ecmwf.int/repository/test-data/metview/gallery/2m_temperature.grib  -o data.grib
+          curl -L https://github.com/ecmwf/climetlab/raw/main/docs/examples/test.grib -o climetlab.grib
+          curl -L https://github.com/ecmwf/climetlab/raw/main/docs/examples/test.nc -o climetlab.nc
+          ls -l
+        working-directory: tests
 
-    - run: pytest --verbose -s
-      working-directory: tests
-      timeout-minutes: 2
+      - run: pytest --verbose -s
+        working-directory: tests
+        timeout-minutes: 2
 
-    - uses: actions/upload-artifact@v2
-      with:
-        name: tests-windows-${{ matrix.python-version }}-${{ matrix.architecture }}
-        path: tests/*.png
+      - uses: actions/upload-artifact@v4
+        with:
+          name: tests-windows-${{ matrix.python-version }}-${{ matrix.architecture }}
+          path: tests/*.png
 
   deploy:
     if: ${{ github.event_name == 'release' }}
@@ -213,21 +212,21 @@ jobs:
         architecture: ["x64"]
 
     steps:
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
 
-    - run: pip install twine
+      - run: pip install twine
 
-    - uses: actions/download-artifact@v2
-      with:
-        name: wheel-windows-${{ matrix.python-version }}-${{ matrix.architecture }}
+      - uses: actions/download-artifact@v4
+        with:
+          name: wheel-windows-${{ matrix.python-version }}-${{ matrix.architecture }}
 
-    - run: twine upload *.whl
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+      - run: twine upload *.whl
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
 
   notify:
     if: ${{ github.event_name == 'release' }}
@@ -239,9 +238,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: mvasigh/dispatch-action@main
-      with:
-        token: ${{ secrets.NOTIFY_ECMWFLIBS }}
-        repo: ecmwflibs
-        owner: ecmwf
-        event_type: ecmwflibs-windows-uploaded
+      - uses: mvasigh/dispatch-action@main
+        with:
+          token: ${{ secrets.NOTIFY_ECMWFLIBS }}
+          repo: ecmwflibs
+          owner: ecmwf
+          event_type: ecmwflibs-windows-uploaded


### PR DESCRIPTION
Update upload-artifact and download-artifact actions to v4 as v3 and older are deprecated and will soon be removed. See https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/